### PR TITLE
Set up config file for polygon testnet (mumbai)

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,7 @@
 require("@nomiclabs/hardhat-waffle");
 
+require('dotenv').config();
+
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://hardhat.org/guides/create-task.html
 task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
@@ -16,6 +18,15 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
-module.exports = {
-  solidity: "0.8.4",
-};
+ module.exports = {
+   defaultNetwork: "mumbai",
+   networks: {
+     hardhat: {},
+     localhost: {},
+     mumbai: {
+       url: process.env.API_URL,
+       accounts: [`0x${process.env.PRIVATE_KEY}`]
+     },
+   },
+   solidity: "0.8.9",
+ }


### PR DESCRIPTION
Requires you to add .env file in root directory with following variables:

```
API_URL="<api url from alchemy>"
PRIVATE_KEY="<private key of minter>"
```

To deploy to mumbai:
`npx hardhat run scripts/deploy.js --network mumbai`

We will have to define our deploy.js script after we define the TickerFactory contract and the Ticket contract. Note, this will only allow minting a single set of mints for each hardhat run call from our terminals. We will still need to allow minting from the client.
